### PR TITLE
simplify useHandle for synchronous repo.find

### DIFF
--- a/packages/automerge-repo-react-hooks/src/index.ts
+++ b/packages/automerge-repo-react-hooks/src/index.ts
@@ -19,16 +19,7 @@ export function useHandle<T>(
 ): [DocHandle<T> | undefined, (d: DocHandle<T>) => void] {
   const repo = useRepo()
 
-  const [handle, setHandle] = useState<DocHandle<T>>()
-
-  useEffect(() => {
-    ;(async () => {
-      const handle: DocHandle<T> = await repo.find(documentId)
-      setHandle(handle)
-    })()
-  }, [repo, documentId])
-
-  return [handle, setHandle]
+  return useState<DocHandle<T>>(repo.find(documentId))
 }
 
 export function useDocument<T>(


### PR DESCRIPTION
i think it doesn't make sense for `setHandle` to be exposed here and this
should just be `useMemo`, but taking it one step at a time.
