### PR TITLE
remove peers on disconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 build
 .vscode
+.idea

--- a/packages/automerge-repo-sync-server/package.json
+++ b/packages/automerge-repo-sync-server/package.json
@@ -8,7 +8,7 @@
     "start": "node ./src/index.js"
   },
   "dependencies": {
-    "@automerge/automerge": "^2.0.0-alpha.4",
+    "@automerge/automerge": "^2.0.1-alpha.1",
     "automerge-repo": "*",
     "automerge-repo-network-websocket": "*",
     "automerge-repo-storage-nodefs": "*",

--- a/packages/automerge-repo-sync-server/src/index.js
+++ b/packages/automerge-repo-sync-server/src/index.js
@@ -21,7 +21,7 @@ const config = {
   sharePolicy: (peerId) => false,
 }
 
-const PORT = 3030
+const PORT = process.env.PORT !== undefined ? parseInt(process.env.PORT) : 3030
 const serverRepo = new Repo(config)
 const app = express()
 app.use(express.static("public"))

--- a/packages/automerge-repo/src/Repo.ts
+++ b/packages/automerge-repo/src/Repo.ts
@@ -58,6 +58,10 @@ export class Repo extends DocCollection {
       synchronizer.addPeer(peerId, sharePolicy(peerId))
     })
 
+    networkSubsystem.on("peer-disconnected", ({peerId}) => {
+      synchronizer.removePeer(peerId)
+    })
+
     this.on("document", ({ handle }) => {
       synchronizer.addDocument(handle.documentId)
     })

--- a/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/CollectionSynchronizer.ts
@@ -87,5 +87,11 @@ export class CollectionSynchronizer extends EventEmitter<SyncMessages> {
     }
   }
 
-  // TODO: need to handle vanishing peers somehow and deliberately removing them
+  removePeer(peerId: PeerId) {
+    log(`removing peer ${peerId}`)
+    delete this.peers[peerId]
+    for (const docSynchronizer of Object.values(this.syncPool)) {
+      docSynchronizer.endSync(peerId)
+    }
+  }
 }

--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -110,9 +110,9 @@ export class DocSynchronizer
     this.sendSyncMessage(peerId, documentId, doc)
   }
 
-  // TODO: This is never called :/
   endSync(peerId: PeerId) {
-    this.peers.filter((p) => p !== peerId)
+    log(`removing peer ${peerId}`)
+    this.peers = this.peers.filter((p) => p !== peerId)
   }
 
   async onSyncMessage(
@@ -135,7 +135,6 @@ export class DocSynchronizer
         `[${this.handle.documentId}]->[${peerId}]: receiveSync: ${message.byteLength}b`,
         decoded
       )
-      console.log("just testing logging 123")
       conciseLog(
         `📫 receiveSyncMessage\t${JSON.stringify({
           documentId: this.handle.documentId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,30 +34,30 @@
   dependencies:
     "@atjson/hir" "0.22.14"
 
-"@automerge/automerge-wasm@0.1.15":
-  version "0.1.15"
-  resolved "https://registry.yarnpkg.com/@automerge/automerge-wasm/-/automerge-wasm-0.1.15.tgz#2999c49d1fa27bd84433c0b2b196c22783200f1b"
-  integrity sha512-n1K8Jq4ICb5U5F+vYkUx5o86b7CaQo1CufOsHDAJGycDyA1ATKqh0Bkf6imTue9BHbncpmP95vX8BKERkKR2Qg==
+"@automerge/automerge-wasm@0.1.17":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@automerge/automerge-wasm/-/automerge-wasm-0.1.17.tgz#f4011fdb891f6f4ff925f165af090b604d5df7de"
+  integrity sha512-P+ZsqPEorceLhDX467RA0hHP/0Zh2NXCe32uoX6RbIgj6/Io97YRmNlMw2HrZx7tKsUis+DNIxWxk74RvoIkFg==
 
-"@automerge/automerge-wasm@0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@automerge/automerge-wasm/-/automerge-wasm-0.1.9.tgz#f372b6d4826ecc25bd9baa725b03be80d7b162ec"
-  integrity sha512-lqb+dZAgWyVwIXfQbLhSdt0zecr0jsxKztuTyu0PcMm3i0NeWXvPuxLcJvZ72K2/V7mKnNYs2cqYZFXYqC3yKg==
+"@automerge/automerge-wasm@0.1.18":
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/@automerge/automerge-wasm/-/automerge-wasm-0.1.18.tgz#83b09a7f6517856bd54e827389519754470c2f4a"
+  integrity sha512-0tlCLINoO3+lVP4vQmu2sMYoTjQIyKcXcPJB7wq679d6oz+2Y0Rg+X1G7cj7PFAPEhssKLhsoy6Vwy5her7LCA==
 
 "@automerge/automerge@*":
-  version "2.0.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@automerge/automerge/-/automerge-2.0.0-beta.4.tgz#aff6a98855ac8d283d6af262b0024e9e314af2a3"
-  integrity sha512-xloD4qS11FosiV8KohtGVM+Xdkqpocwovi4VfRdF58WaNz+LwQdOZJoxURoVsfKaGnpz4NyyKYdxpxqFG/Rl1w==
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@automerge/automerge/-/automerge-2.0.0.tgz#2becd93b0941af2b62ad5b953337ad886395b359"
+  integrity sha512-hQK5hvo+1ngFxEIxxitO1cnCPDdNFstfvPfTiIygwE1NFcxvBnUOpA/Egt+Z+HgYaK+czf4SxSNelXUY74oQwg==
   dependencies:
-    "@automerge/automerge-wasm" "0.1.15"
+    "@automerge/automerge-wasm" "0.1.17"
     uuid "^8.3"
 
-"@automerge/automerge@^2.0.0-alpha.4":
-  version "2.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@automerge/automerge/-/automerge-2.0.0-alpha.4.tgz#e1737ae89c15e7d7f0cf5fd6e9d6abcee47883ce"
-  integrity sha512-YCKcJOmDpo7qPPriDAwKCu8bvLyrEP20jBhrETJJAt51jY9L6K2sLVB50P4z5vhVASggHfHPSwikh/35HH8QQA==
+"@automerge/automerge@^2.0.1-alpha.1":
+  version "2.0.1-alpha.1"
+  resolved "https://registry.yarnpkg.com/@automerge/automerge/-/automerge-2.0.1-alpha.1.tgz#cf52250585b94b16b76931ffb44b310be9f56fe1"
+  integrity sha512-Gm5Rp7x0j08+ls68u5DxvR6W2xEKQTjR/vQUtVH5wdxCgRe8k3Uztk4FL9/eKlxX/Jb62iMHZvEhK6sE0RIdbg==
   dependencies:
-    "@automerge/automerge-wasm" "0.1.9"
+    "@automerge/automerge-wasm" "0.1.18"
     uuid "^8.3"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":


### PR DESCRIPTION
(result of me and @paulsonnentag pairing)

Reloading a client tab in Chrome creates a new peer. (Unclear if this is expected behavior?)

Previously we would see the server continue to send messages to the now-disconnected peer; thus reloading the same tab a lot would result in a lot of "phantom peers" building up.

This PR handles socket disconnection by removing the peer from the network adapter and collection/doc synchronizers.

It's been tested with a sync server running on a DigitalOcean box, when we connect a few clients and reload them a lot, we've confirmed that no messages get sent out to disconnected peers.

Questions / todos where we need more context from @pvh:

- Is it correct/reasonable to remove the peer from all synchronizers once it disconnects? Wasn't sure how long-lived peers are expected to be.
- Is it expected behavior that reloading a tab in Chrome creates a new peer with a new shared worker ID?
- We should probably add similar behavior to other network adapters, I haven't looked at anything except the Node WS adapter
- Are "leave" messages expected from a client before it disconnects? There's some stub code for handling them but they don't seem to happen in practice.