### PR TITLE
Use weak refs so message channels of inactive tabs get garbage collected

### DIFF
--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -13,13 +13,13 @@ interface PortRefEvents {
   close: () => void
 }
 
-export interface MessagePortRef extends EventEmitter<PortRefEvents> {
+interface MessagePortRef extends EventEmitter<PortRefEvents> {
   start (): void
   postMessage (message: any, transferable?: Transferable[]): void
   isAlive () : boolean
 }
 
-export class WeakMessagePortRef extends EventEmitter<PortRefEvents> implements MessagePortRef {
+class WeakMessagePortRef extends EventEmitter<PortRefEvents> implements MessagePortRef {
 
   private weakRef : WeakRef<MessagePort>
   private isDisconnected = false
@@ -85,8 +85,7 @@ export class WeakMessagePortRef extends EventEmitter<PortRefEvents> implements M
   }
 }
 
-
-export class StrongMessagePortRef extends EventEmitter<PortRefEvents> implements MessagePortRef {
+class StrongMessagePortRef extends EventEmitter<PortRefEvents> implements MessagePortRef {
   constructor(private port: MessagePort) {
     port.addEventListener("message", (event) => {
       this.emit("message", event)
@@ -117,9 +116,9 @@ export class MessageChannelNetworkAdapter
   messagePortRef: MessagePortRef
   peerId?: PeerId
 
-  constructor(messagePortRef: MessagePortRef) {
+  constructor(messagePort: MessagePort, useWeakRef: boolean = false) {
     super()
-    this.messagePortRef = messagePortRef
+    this.messagePortRef = useWeakRef ? new WeakMessagePortRef(messagePort) : new StrongMessagePortRef(messagePort)
   }
 
   connect(peerId: PeerId) {

--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -161,7 +161,6 @@ export class MessageChannelNetworkAdapter
     })
 
     this.messagePortRef.addListener("close", () => {
-      console.log("close message port")
       this.emit("close")
     })
   }

--- a/packages/automerge-repo-network-messagechannel/src/index.ts
+++ b/packages/automerge-repo-network-messagechannel/src/index.ts
@@ -107,6 +107,15 @@ class StrongMessagePortRef extends EventEmitter<PortRefEvents> implements Messag
   }
 }
 
+interface MessageChannelNetworkAdapterConfig {
+  // optional parameter to use a weak ref to reference the message port that is passed to the adapter.
+  // This option is useful when using a message channel with a shared worker.
+  // If you use a network adapter with useWeakRef = true in the shared worker and in the main thread network adapters
+  // with strong refs the network adapter will be automatically garbage collected if you close a page.
+  // The garbage collection doesn't happen immediately; there might be some time in between when the page is closed
+  // and when the port is garbage collected
+  useWeakRef?: boolean
+}
 
 export class MessageChannelNetworkAdapter
   extends EventEmitter<NetworkAdapterEvents>
@@ -116,8 +125,11 @@ export class MessageChannelNetworkAdapter
   messagePortRef: MessagePortRef
   peerId?: PeerId
 
-  constructor(messagePort: MessagePort, useWeakRef: boolean = false) {
+  constructor(messagePort: MessagePort, config : MessageChannelNetworkAdapterConfig = {}) {
     super()
+
+    const useWeakRef = config.useWeakRef ?? false
+
     this.messagePortRef = useWeakRef ? new WeakMessagePortRef(messagePort) : new StrongMessagePortRef(messagePort)
   }
 

--- a/packages/automerge-repo/src/network/NetworkSubsystem.ts
+++ b/packages/automerge-repo/src/network/NetworkSubsystem.ts
@@ -36,6 +36,7 @@ interface DisconnectedDetails {
 
 export interface NetworkAdapterEvents {
   open: (event: AdapterOpenDetails) => void
+  close: () => void
   "peer-candidate": (event: PeerCandidateDetails) => void
   "peer-disconnected": (event: DisconnectedDetails) => void
   message: (event: InboundMessageDetails) => void
@@ -125,6 +126,14 @@ export class NetworkSubsystem extends EventEmitter<NetworkEvents> {
       }
 
       this.emit("message", msg)
+    })
+
+    networkAdapter.on("close", () => {
+      Object.entries(this.peerIdToAdapter).forEach(([peerId, other]) => {
+        if (other === networkAdapter) {
+          delete this.peerIdToAdapter[peerId as PeerId]
+        }
+      })
     })
 
     this.channels.forEach((c) => networkAdapter.join(c))


### PR DESCRIPTION
Inspired by: https://stackoverflow.com/questions/13662089/javascript-how-to-know-if-a-connection-with-a-shared-worker-is-still-alive#answer-71499332


This pull request adds a second optional parameter to the MessageChannelNetworkAdapter which allows to specify that the ports should be referenced using weak refs

```javascript
new MessageChannelNetworkAdapter(port, {useWeakRef: true}) 
```

If we use strong refs in the browser and weak refs in the shared worker inactive ports will be garbage collected eventually

