### PR TITLE
Add fix and test for syncValue not returning following an incremental load on an existing document

### DIFF
--- a/packages/automerge-repo/src/DocHandle.ts
+++ b/packages/automerge-repo/src/DocHandle.ts
@@ -136,7 +136,10 @@ export class DocHandle<T> extends EventEmitter<DocHandleEvents<T>> {
     log(`[${this.documentId}]: syncValue,`, this.doc)
     if (this.state == "loading") {
       log(`[${this.documentId}]: value: (${this.state}, waiting for syncing)`)
-      await new Promise((resolve) => this.once("syncing", () => resolve(true)))
+      await new Promise((resolve) => {
+        this.once("syncing", () => resolve(true))
+        this.once("ready", () => resolve(true))
+      })
     } else {
       await new Promise((resolve) => setTimeout(() => resolve(true), 0))
     }

--- a/packages/automerge-repo/test/DocHandle.test.ts
+++ b/packages/automerge-repo/test/DocHandle.test.ts
@@ -40,6 +40,23 @@ describe("DocHandle", () => {
       }
     })
   })
+  
+  it("should return syncValue following an incremental load on an existing document", (done) => {
+    const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)
+    assert(handle.ready() === false)
+    
+    handle.syncValue().then((doc) => {
+      try {
+        assert(handle.ready() === true)
+        assert(doc.foo === "bar")
+        done()
+      } catch (e) {
+        done(e)
+      }
+    })
+
+    handle.loadIncremental(Automerge.save(Automerge.change<{foo: string}>(Automerge.init(), (d) => (d.foo = "bar"))))
+  })
 
   it("should block changes until ready()", (done) => {
     const handle = new DocHandle<TestDoc>("test-document-id" as DocumentId)


### PR DESCRIPTION
If a document is looked for in the repo, and it exists in the `StorageAdapter`, but not in any of the peers, it is loaded correctly, but no sync messages are generated.

This pull request unblocks the `syncValue()` method, which currently waits for a `syncing` event. `incrementalLoad` only emits a `ready` event.

NB. [This test](https://github.com/pvh/automerge-repo/blob/0746eba5c9b9159f598634a9427662b2d93817fe/packages/automerge-repo/test/Repo.test.ts#L117) was already failing when I started to look at this issue