### PR TITLE
A peer no longer receives sync messages if it leaves and then rejoins

### DIFF
--- a/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
+++ b/packages/automerge-repo/src/synchronizer/DocSynchronizer.ts
@@ -33,13 +33,14 @@ export class DocSynchronizer
     if (!peerId) {
       throw new Error("Tried to load a missing peerId")
     }
+    
+    if (!this.peers.includes(peerId)) {
+      log("adding a new peer", peerId)
+      this.peers.push(peerId)
+    }
 
     let syncState = this.syncStates[peerId]
     if (!syncState) {
-      if (!this.peers.includes(peerId)) {
-        log("adding a new peer", peerId)
-        this.peers.push(peerId)
-      }
       syncState = Automerge.initSyncState()
     }
 

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -29,14 +29,6 @@ describe("DocSynchronizer", () => {
     })
   })
 
-  it("should emit a syncMessage to peers when the handle is updated", (done) => {
-    docSynchronizer.beginSync("imaginary-peer-id" as PeerId)
-    docSynchronizer.once("message", () => done())
-    handle.change((doc) => {
-      doc.foo = "bar"
-    })
-  })
-
   it("should emit a syncMessage to peers when the peer is removed, then re-added", (done) => {
     docSynchronizer.beginSync("imaginary-peer-id-2" as PeerId).then(() => {
       handle.change((doc) => {

--- a/packages/automerge-repo/test/DocSynchronizer.test.ts
+++ b/packages/automerge-repo/test/DocSynchronizer.test.ts
@@ -4,15 +4,57 @@ import { DocSynchronizer } from "../src/synchronizer/DocSynchronizer"
 import { PeerId } from "../src/network/NetworkSubsystem"
 
 describe("DocSynchronizer", () => {
-  const handle = new DocHandle("synced-doc" as DocumentId, true)
-  const docSynchronizer = new DocSynchronizer(handle)
+  let handle: DocHandle<{foo: string}>
+  let docSynchronizer: DocSynchronizer
+
+  beforeEach(() => {
+    handle = new DocHandle<{foo: string}>("synced-doc" as DocumentId, true)
+    docSynchronizer = new DocSynchronizer(handle)
+  })
 
   it("should take the handle passed into it", () => {
     assert(docSynchronizer.handle === handle)
   })
 
   it("should emit a syncMessage when beginSync is called", (done) => {
-    docSynchronizer.on("message", () => done())
+    docSynchronizer.once("message", () => done())
     docSynchronizer.beginSync("imaginary-peer-id" as PeerId)
+  })
+
+  it("should emit a syncMessage to peers when the handle is updated", (done) => {
+    docSynchronizer.beginSync("imaginary-peer-id" as PeerId)
+    docSynchronizer.once("message", () => done())
+    handle.change((doc) => {
+      doc.foo = "bar"
+    })
+  })
+
+  it("should emit a syncMessage to peers when the handle is updated", (done) => {
+    docSynchronizer.beginSync("imaginary-peer-id" as PeerId)
+    docSynchronizer.once("message", () => done())
+    handle.change((doc) => {
+      doc.foo = "bar"
+    })
+  })
+
+  it("should emit a syncMessage to peers when the peer is removed, then re-added", (done) => {
+    docSynchronizer.beginSync("imaginary-peer-id-2" as PeerId).then(() => {
+      handle.change((doc) => {
+        doc.foo = "bar"
+      })
+      docSynchronizer.endSync("imaginary-peer-id-2" as PeerId)
+      docSynchronizer.beginSync("imaginary-peer-id-2" as PeerId).then(
+        () => {
+          docSynchronizer.once("message", (event) => {
+            if (event.targetId === "imaginary-peer-id-2") {
+              done()
+            }
+          })
+          handle.change((doc) => {
+            doc.foo = "baz"
+          })
+        }
+      )
+    })
   })
 })


### PR DESCRIPTION
This PR contains a failing test to show that a peer registered with a `docSynchronizer` no longer receives sync messages if it leaves and then rejoins.